### PR TITLE
set project Java version via maven property

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -4,6 +4,9 @@
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
   <version>${version}</version>
+  <properties>
+    <java.version>${java_version}</java.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.codeborne</groupId>
@@ -38,6 +41,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>


### PR DESCRIPTION
Fixes issue with Java version incompatibility

The error I get in IDE after trying first-time run sample test:

_Source option 5 is no longer supported. Use 6 or later.
The language level is invalid or missing in pom.xml. Current project JDK is 11._